### PR TITLE
Support projects built with Babel 7

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -186,7 +186,7 @@ export default function ({ types:t }) {
       },
       CallExpression(path, state) {
         const { opts } = state;
-        const {filename} = (path && path.hub && path.hub.file) || (state && state.file);
+        const {filename} = (path && path.hub && path.hub.file && path.hub.file.opts) || (state && state.file);
         if (cache[filename]) return;
         const { callee, arguments: args } = path.node;
         if (isRouterCall(callee, path.scope)) {

--- a/src/index.js
+++ b/src/index.js
@@ -184,8 +184,9 @@ export default function ({ types:t }) {
           delete cache[filename];
         },
       },
-      CallExpression(path, { opts }) {
-        const { filename } = path.hub.file.opts;
+      CallExpression(path, state) {
+        const { opts } = state;
+        const {filename} = (path && path.hub && path.hub.file) || (state && state.file);
         if (cache[filename]) return;
         const { callee, arguments: args } = path.node;
         if (isRouterCall(callee, path.scope)) {


### PR DESCRIPTION
Fixes: #14 
Should allow projects with Babel 7 to use `babel-plugin-dva-hmr` for the time being.

After an upgrade of a work project Babel 7, we experienced `cannot read property 'file' of undefined` errors because of this plugin. This commit fixes that and the plugin works as expected.

Later, a whole plugin transfer to Babel 7 could be implemented to keep up with the times.